### PR TITLE
docs(extension): add privacy policy for store submission

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@
 main.js
 *.js.map
 
+# Extension upload package (built on demand for the Chrome Web Store)
+bookmarker-extension.zip
+
 # Dependencies
 node_modules/
 

--- a/extension/PRIVACY.md
+++ b/extension/PRIVACY.md
@@ -1,0 +1,13 @@
+# Privacy Policy: Bookmarker for Obsidian (browser extension)
+
+Last updated: 2026-06-14
+
+Bookmarker for Obsidian does not collect, store, sell, or transfer any personal data.
+
+The extension requests the `activeTab` permission and reads the active tab's URL only at the moment you click its toolbar button. It uses that URL for one thing: to pass it to the Obsidian Bookmarker plugin through the `obsidian://bookmark` link, so the plugin can save the page in your vault.
+
+The extension runs no server of its own and sends no data to the developer. It sets no cookies, runs no analytics, and tracks nothing. It requests no host permissions and reads no other tab.
+
+Any later network activity (fetching the page, its image, or proposing tags) happens inside the Obsidian plugin on your own machine, not in this extension. The plugin's own behavior is documented in its repository.
+
+Contact: stefano@stefer.it

--- a/extension/SUBMISSION.md
+++ b/extension/SUBMISSION.md
@@ -64,13 +64,9 @@ This is where most first submissions get held up. Fill every field.
 - **Single purpose:** Save the current browser tab to an Obsidian vault by handing its URL to the Bookmarker Obsidian plugin.
 - **`activeTab` justification:** The extension reads the active tab's URL only when the user clicks the toolbar button, to pass it to Obsidian. It uses no host permissions and accesses no other tabs.
 - **Data usage:** the extension collects nothing. Check every "I do not sell or transfer…" and "I do not use or transfer for purposes unrelated…" box, then certify compliance.
-- **Privacy policy URL:** Chrome requires one even when you collect no data. Host the `PRIVACY.md` text (below) somewhere public and paste its URL. A GitHub raw link to a `PRIVACY.md` in the repo works, or a GitHub Pages page.
+- **Privacy policy URL:** Chrome requires one even when you collect no data. The policy lives in `extension/PRIVACY.md`. Once it is on `main`, paste this URL into the form:
 
-### Privacy policy text (host this, then link it)
-
-Bookmarker for Obsidian does not collect, store, sell, or transfer any personal data. The extension requests the `activeTab` permission and reads the active tab's URL only at the moment you click its toolbar button, solely to pass that URL to the Obsidian Bookmarker plugin via the `obsidian://bookmark` link. No data is sent to any server operated by the developer. No analytics, no tracking, no cookies.
-
-Contact: stefano@stefer.it
+  `https://github.com/istefox/obsidian-bookmarker/blob/main/extension/PRIVACY.md`
 
 ## Step 4: Submit and wait
 


### PR DESCRIPTION
Add `extension/PRIVACY.md` (no data collected, `activeTab` only) to meet the Chrome Web Store privacy-policy URL requirement, and link it from `SUBMISSION.md`. Ignore the built upload zip.

Once merged, the privacy policy URL for the store form is:
`https://github.com/istefox/obsidian-bookmarker/blob/main/extension/PRIVACY.md`