### PR TITLE
docs: link the Chrome Web Store listing in the READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,9 @@ Bookmarker is not in the community plugin directory yet, so install it manually:
 
 ### Browser extension (desktop one-click)
 
-The `extension/` folder holds a small Manifest V3 extension. Load it unpacked (Chrome: `chrome://extensions` → Developer mode → Load unpacked → select `extension/`). Clicking its toolbar button opens `obsidian://bookmark?url=<current tab>`, which hands the URL to the plugin. See `extension/README.md` for details.
+Install it from the [Chrome Web Store](https://chromewebstore.google.com/detail/gmpfgkokpoblhaajglclanlmfnldoiee) (Chrome, Edge, Brave, Arc). Click its toolbar button on any page and Obsidian saves the bookmark.
+
+The `extension/` folder also holds the source. To run it unpacked for development: Chrome `chrome://extensions` → Developer mode → Load unpacked → select `extension/`. The button opens `obsidian://bookmark?url=<current tab>`, which hands the URL to the plugin. See `extension/README.md` for details.
 
 ### Mobile (iOS/iPad)
 

--- a/extension/README.md
+++ b/extension/README.md
@@ -9,12 +9,18 @@ current tab's URL to the **Bookmarker** Obsidian plugin through
 See `docs/architecture/ADR-001` in the plugin repo for why the capture logic lives
 in the plugin and not here.
 
+## Install
+
+From the [Chrome Web Store](https://chromewebstore.google.com/detail/gmpfgkokpoblhaajglclanlmfnldoiee):
+one click, with automatic updates. Then pin the **Bookmarker** action to the toolbar.
+The steps in "Install (unpacked, for development)" below load the source instead.
+
 ## Requirements
 
 - The **Bookmarker** Obsidian plugin installed and enabled, with Obsidian running (or
   launchable) — it registers the `obsidian://bookmark` handler.
 
-## Install (unpacked, for personal use)
+## Install (unpacked, for development)
 
 1. Open `chrome://extensions`.
 2. Enable **Developer mode** (top right).


### PR DESCRIPTION
The extension is published on the Chrome Web Store. Link the store page from both READMEs so the plugin and the extension point to each other.

- `README.md`: store install link in the browser extension section, with the unpacked steps kept for development.
- `extension/README.md`: store install section, unpacked steps relabeled "for development".

Store URL (tracking param stripped): https://chromewebstore.google.com/detail/gmpfgkokpoblhaajglclanlmfnldoiee