### PR TITLE
docs: record the saved-page badge decision in ADR-001

### DIFF
--- a/docs/architecture/ADR-001-one-click-capture-via-browser-extension.md
+++ b/docs/architecture/ADR-001-one-click-capture-via-browser-extension.md
@@ -67,6 +67,21 @@ Extension POSTs to `https://127.0.0.1:27124/` exposed by the
 and would push part of the capture chain into the extension. Fails the cross-platform
 requirement and adds user friction.
 
+### D) Saved-page indicator badge in the extension (rejected)
+Considered 2026-06-15. A Raindrop-style checkmark on the extension icon when the
+current page is already bookmarked. It needs two things the design rules out. First,
+to badge pages as you browse, the extension must read every tab's URL without a
+click, which means the `tabs` permission or host permissions instead of `activeTab`.
+That triggers the "access your data on all websites" warning, a privacy disclosure,
+and a fresh Web Store review, so the minimal-permission posture is gone. Second, the
+extension cannot read the vault, so it would need either a localhost server in the
+plugin (desktop-only, and a backend by another name, which contradicts this ADR) or
+a partial list of URLs saved only through the extension (it misses captures from the
+command palette, imports, and other devices). Rejected to keep the no-backend,
+minimal-permission, mobile-safe design intact. If an "already saved" hint is ever
+wanted, it belongs inside Obsidian, where the duplicate detection at capture already
+does this, not in the browser extension.
+
 ## Consequences
 
 **Positive**


### PR DESCRIPTION
Add rejected alternative **D) Saved-page indicator badge in the extension** to ADR-001 (dated 2026-06-15). A Raindrop-style "already saved" checkmark on the extension icon would require both broad `tabs`/host permissions (proactively reading every tab URL, which triggers the "access your data on all websites" warning and a Web Store re-review) and a bridge to the vault (a desktop-only localhost server in the plugin, a backend by another name). Both break the no-backend, minimal-permission, mobile-safe design, so it stays out. The note records that an "already saved" hint, if ever wanted, belongs inside Obsidian (the capture-time duplicate detection already does this).

Docs only.