### PR TITLE
feat(board): unify toolbar button sizing and add bulk delete for broken links

### DIFF
--- a/src/bookmark-view.ts
+++ b/src/bookmark-view.ts
@@ -62,6 +62,7 @@ export class BookmarkView extends ItemView {
 	private gridEl!: HTMLElement;
 	private tagSectionEl!: HTMLElement;
 	private countEl!: HTMLElement;
+	private deleteBrokenBtn!: HTMLButtonElement;
 
 	constructor(leaf: WorkspaceLeaf, plugin: BookmarkerPlugin) {
 		super(leaf);
@@ -268,7 +269,7 @@ export class BookmarkView extends ItemView {
 		});
 
 		const selectAll = toolbar.createEl("button", {
-			cls: "bookmarker-refresh",
+			cls: "bookmarker-toolbar-btn",
 			text: "Select all",
 		});
 		selectAll.addEventListener("click", () => {
@@ -277,7 +278,7 @@ export class BookmarkView extends ItemView {
 		});
 
 		const selectNone = toolbar.createEl("button", {
-			cls: "bookmarker-refresh",
+			cls: "bookmarker-toolbar-btn",
 			text: "Select none",
 		});
 		selectNone.addEventListener("click", () => {
@@ -285,8 +286,16 @@ export class BookmarkView extends ItemView {
 			this.renderGrid();
 		});
 
+		const deleteBrokenBtn = toolbar.createEl("button", {
+			cls: "bookmarker-toolbar-btn bookmarker-delete-broken",
+			text: "Delete broken",
+		});
+		deleteBrokenBtn.style.display = "none";
+		deleteBrokenBtn.addEventListener("click", () => void this.deleteBrokenSelected());
+		this.deleteBrokenBtn = deleteBrokenBtn;
+
 		const refresh = toolbar.createEl("button", {
-			cls: "bookmarker-refresh",
+			cls: "bookmarker-toolbar-btn",
 			text: "Refresh",
 		});
 		refresh.addEventListener("click", () => {
@@ -430,6 +439,8 @@ export class BookmarkView extends ItemView {
 		this.gridEl.empty();
 		const items = this.filtered();
 		this.countEl.setText(`${items.length} bookmark${items.length === 1 ? "" : "s"}`);
+		this.deleteBrokenBtn.style.display =
+			this.brokenOnly && this.selected.size > 0 ? "" : "none";
 		if (items.length === 0) {
 			this.gridEl.createDiv({
 				cls: "bookmarker-empty",
@@ -638,6 +649,23 @@ export class BookmarkView extends ItemView {
 			const msg = error instanceof Error ? error.message : String(error);
 			new Notice(`Delete failed: ${msg}`);
 		}
+	}
+
+	private async deleteBrokenSelected(): Promise<void> {
+		const targets = this.items.filter(
+			(i) => i.broken && this.selected.has(i.file.path),
+		);
+		if (targets.length === 0) return;
+		let failed = 0;
+		for (const item of targets) {
+			try {
+				await this.app.fileManager.trashFile(item.file);
+				this.selected.delete(item.file.path);
+			} catch {
+				failed++;
+			}
+		}
+		if (failed > 0) new Notice(`${failed} deletion${failed === 1 ? "" : "s"} failed.`);
 	}
 
 	private moveToCategory(item: BookmarkItem): void {

--- a/styles.css
+++ b/styles.css
@@ -42,11 +42,26 @@
 	display: inline-flex;
 	align-items: center;
 	gap: var(--size-2-1);
-	padding: 2px 8px;
+	padding: 3px 10px;
 	background: var(--tag-background);
 	color: var(--tag-color);
 	border-radius: var(--radius-s);
 	font-size: var(--font-ui-smaller);
+	line-height: 1.4;
+}
+
+/* Uniform-size toolbar buttons — match the tag-chip height. */
+.bookmarker-toolbar-btn {
+	padding: 3px 10px;
+	font-size: var(--font-ui-smaller);
+	line-height: 1.4;
+	height: auto;
+	cursor: pointer;
+}
+
+.bookmarker-delete-broken {
+	color: var(--text-error);
+	border-color: var(--background-modifier-error-hover);
 }
 
 .bookmarker-tag-remove {


### PR DESCRIPTION
Give every toolbar control the same height by sharing padding, font size, and line height between tag chips and buttons.

Add a "Delete broken" button that appears only when the Broken filter is active and at least one card is selected, sending the selected broken bookmarks to the trash in one action.

## Changes
- `styles.css`: new `.bookmarker-toolbar-btn` class matching tag-chip height; `.bookmarker-delete-broken` danger variant; tag-chip padding/line-height tweak for vertical alignment.
- `src/bookmark-view.ts`: `Select all` / `Select none` / `Refresh` now use the shared button class; new `deleteBrokenBtn` toggled by `renderGrid()` (visible only when `brokenOnly` and selection non-empty); new `deleteBrokenSelected()` trashes selected broken items and reports failures.

Build green (`npm run build`).