### PR TITLE
fix(board): toggle CSS class instead of inline style for delete button

### DIFF
--- a/src/bookmark-view.ts
+++ b/src/bookmark-view.ts
@@ -287,10 +287,9 @@ export class BookmarkView extends ItemView {
 		});
 
 		const deleteBrokenBtn = toolbar.createEl("button", {
-			cls: "bookmarker-toolbar-btn bookmarker-delete-broken",
+			cls: "bookmarker-toolbar-btn bookmarker-delete-broken bookmarker-hidden",
 			text: "Delete broken",
 		});
-		deleteBrokenBtn.style.display = "none";
 		deleteBrokenBtn.addEventListener("click", () => void this.deleteBrokenSelected());
 		this.deleteBrokenBtn = deleteBrokenBtn;
 
@@ -439,8 +438,10 @@ export class BookmarkView extends ItemView {
 		this.gridEl.empty();
 		const items = this.filtered();
 		this.countEl.setText(`${items.length} bookmark${items.length === 1 ? "" : "s"}`);
-		this.deleteBrokenBtn.style.display =
-			this.brokenOnly && this.selected.size > 0 ? "" : "none";
+		this.deleteBrokenBtn.toggleClass(
+			"bookmarker-hidden",
+			!(this.brokenOnly && this.selected.size > 0),
+		);
 		if (items.length === 0) {
 			this.gridEl.createDiv({
 				cls: "bookmarker-empty",

--- a/styles.css
+++ b/styles.css
@@ -64,6 +64,10 @@
 	border-color: var(--background-modifier-error-hover);
 }
 
+.bookmarker-hidden {
+	display: none;
+}
+
 .bookmarker-tag-remove {
 	cursor: pointer;
 	opacity: 0.7;


### PR DESCRIPTION
Review flagged `obsidianmd/no-static-styles-assignment` at src/bookmark-view.ts:293 — the "Delete broken" button set `element.style.display` directly.

Replace both assignments (initial hide + `renderGrid` toggle) with a `.bookmarker-hidden { display: none }` class toggled via `toggleClass`. No behavior change.

Build green, ESLint clean.