### PR TITLE
feat(board): add visible rename/delete affordance to tag chips

### DIFF
--- a/src/bookmark-view.ts
+++ b/src/bookmark-view.ts
@@ -375,9 +375,17 @@ export class BookmarkView extends ItemView {
 				? tags.filter((t) => t.toLowerCase().includes(needle))
 				: tags;
 			for (const tag of shown) {
-				const chip = panel.createSpan({
-					cls: "bookmarker-tag-chip",
+				const chip = panel.createSpan({ cls: "bookmarker-tag-chip" });
+				chip.createSpan({
+					cls: "bookmarker-tag-label",
 					text: `${tag} (${counts.get(tag) ?? 0})`,
+				});
+				// Visible, tap-friendly rename/delete affordance (right-click is not
+				// available on mobile, which the plugin must support).
+				const edit = chip.createSpan({
+					cls: "bookmarker-tag-edit",
+					text: "✎",
+					attr: { "aria-label": "Rename or delete tag", title: "Rename or delete tag" },
 				});
 				if (tag === this.tagFilter) chip.addClass("bookmarker-tag-active");
 				chip.addEventListener("click", () => {
@@ -387,6 +395,11 @@ export class BookmarkView extends ItemView {
 						.forEach((el) => el.removeClass("bookmarker-tag-active"));
 					if (this.tagFilter) chip.addClass("bookmarker-tag-active");
 					this.renderGrid();
+				});
+				edit.addEventListener("click", (event) => {
+					// Don't let the rename tap also toggle the tag filter.
+					event.stopPropagation();
+					this.manageTag(tag);
 				});
 				chip.addEventListener("contextmenu", (event) => {
 					event.preventDefault();

--- a/styles.css
+++ b/styles.css
@@ -77,6 +77,16 @@
 	opacity: 1;
 }
 
+.bookmarker-tag-edit {
+	cursor: pointer;
+	opacity: 0.5;
+	font-size: var(--font-ui-smaller);
+}
+
+.bookmarker-tag-edit:hover {
+	opacity: 1;
+}
+
 .bookmarker-confidence {
 	color: var(--text-muted);
 	font-size: var(--font-ui-smaller);


### PR DESCRIPTION
Each tag chip in the expanded panel now shows a pencil icon that opens the Manage tag dialog to rename the tag everywhere or delete it. Tapping the chip body still filters. This makes the action reachable on mobile, where right-click is not available.

## Changes
- `src/bookmark-view.ts`: split the chip into a label span plus a `.bookmarker-tag-edit` pencil; the pencil opens `manageTag` (stops propagation so it doesn't toggle the filter). Right-click still opens the same dialog on desktop.
- `styles.css`: `.bookmarker-tag-edit` styling (muted, full opacity on hover).

Build green, ESLint clean.