### PR TITLE
feat(board): configurable card size and gap above checkbox and star

### DIFF
--- a/src/bookmark-view.ts
+++ b/src/bookmark-view.ts
@@ -160,7 +160,19 @@ export class BookmarkView extends ItemView {
 		this.loadBookmarks();
 		this.renderToolbar();
 		this.gridEl = this.contentEl.createDiv({ cls: "bookmarker-grid" });
+		this.applyCardSize();
 		this.renderGrid();
+	}
+
+	/** Drive the grid's minimum column width from the chosen card size. */
+	private applyCardSize(): void {
+		const min =
+			this.plugin.settings.cardSize === "small"
+				? "160px"
+				: this.plugin.settings.cardSize === "large"
+					? "300px"
+					: "220px";
+		this.gridEl.setCssProps({ "--bm-card-min": min });
 	}
 
 	private loadBookmarks(): void {
@@ -292,6 +304,23 @@ export class BookmarkView extends ItemView {
 		});
 		deleteBrokenBtn.addEventListener("click", () => void this.deleteBrokenSelected());
 		this.deleteBrokenBtn = deleteBrokenBtn;
+
+		const sizeSel = toolbar.createEl("select", { cls: "bookmarker-size-select" });
+		for (const [value, label] of [
+			["small", "Small cards"],
+			["medium", "Medium cards"],
+			["large", "Large cards"],
+		] as const) {
+			sizeSel.createEl("option", { value, text: label });
+		}
+		sizeSel.value = this.plugin.settings.cardSize;
+		sizeSel.addEventListener("change", () => {
+			const size = sizeSel.value;
+			this.plugin.settings.cardSize =
+				size === "small" || size === "large" ? size : "medium";
+			void this.plugin.saveSettings();
+			this.applyCardSize();
+		});
 
 		const refresh = toolbar.createEl("button", {
 			cls: "bookmarker-toolbar-btn",
@@ -516,7 +545,9 @@ export class BookmarkView extends ItemView {
 
 		const cover = card.createDiv({ cls: "bookmarker-card-cover" });
 
-		const select = cover.createEl("input", {
+		// Checkbox and star live on the card (not the cover) so they sit in the
+		// small strip above the image instead of glued to its top edge.
+		const select = card.createEl("input", {
 			cls: "bookmarker-card-select",
 			attr: { type: "checkbox", "aria-label": "Select bookmark" },
 		});
@@ -534,7 +565,7 @@ export class BookmarkView extends ItemView {
 			cover.setText(item.domain || "No cover");
 		}
 
-		const star = cover.createSpan({
+		const star = card.createSpan({
 			cls: "bookmarker-card-star",
 			text: item.favorite ? "★" : "☆",
 		});

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -23,6 +23,7 @@ export interface BookmarkerSettings {
 	organizeBatchCap: number;
 	brokenFolderName: string;
 	brokenDefaultRemediation: "wayback" | "move" | "mark";
+	cardSize: "small" | "medium" | "large";
 }
 
 export const DEFAULT_SETTINGS: BookmarkerSettings = {
@@ -45,6 +46,7 @@ export const DEFAULT_SETTINGS: BookmarkerSettings = {
 	organizeBatchCap: 50,
 	brokenFolderName: "_broken",
 	brokenDefaultRemediation: "mark",
+	cardSize: "medium",
 };
 
 export class BookmarkerSettingTab extends PluginSettingTab {

--- a/styles.css
+++ b/styles.css
@@ -215,13 +215,17 @@
 
 .bookmarker-grid {
 	display: grid;
-	grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+	grid-template-columns: repeat(auto-fill, minmax(var(--bm-card-min, 220px), 1fr));
 	gap: var(--size-4-3);
 }
 
 .bookmarker-card {
+	position: relative;
 	display: flex;
 	flex-direction: column;
+	/* Small strip of card background above the cover so the checkbox and star
+	   aren't glued to the image's top edge. */
+	padding-top: 10px;
 	border: 1px solid var(--background-modifier-border);
 	border-radius: var(--radius-m);
 	overflow: hidden;


### PR DESCRIPTION
Add a Card size control (Small, Medium, Large) to the board toolbar, applied live through a CSS variable (`--bm-card-min` via `setCssProps`) and saved in settings so it persists. Move the checkbox and star onto the card itself so a small strip of background separates them from the cover image instead of sitting on its top edge.

## Changes
- `src/bookmark-view.ts`: `Card size` toolbar select; `applyCardSize()` sets `--bm-card-min`; checkbox/star moved to card level.
- `src/settings.ts`: `cardSize` setting (default `medium`).
- `styles.css`: grid uses the size var; card `padding-top` strip.

Build green, ESLint clean.