### PR TITLE
feat(board): add category landing view with per-category color and icon

### DIFF
--- a/src/bookmark-view.ts
+++ b/src/bookmark-view.ts
@@ -5,10 +5,12 @@ import {
 	Notice,
 	normalizePath,
 	prepareFuzzySearch,
+	setIcon,
 	TFile,
 	WorkspaceLeaf,
 } from "obsidian";
 import type BookmarkerPlugin from "./main";
+import { CategoryStyleModal } from "./category-style-modal";
 import { isSafeRemoteUrl } from "./url-safety";
 import { fetchHtml, parseMetadata } from "./metadata";
 import { readTaxonomy } from "./taxonomy";
@@ -25,6 +27,13 @@ import { refreshBookmarkCard } from "./refresh-card";
 export const BOOKMARK_VIEW_TYPE = "bookmarker-grid";
 const MAX_CARD_TAGS = 4;
 const MAX_RELATED = 50;
+
+/** Render a category icon: a Lucide name produces an SVG, anything else (emoji) falls back to text. */
+function renderCategoryIcon(el: HTMLElement, value: string): void {
+	el.empty();
+	setIcon(el, value);
+	if (!el.querySelector("svg")) el.setText(value);
+}
 
 interface BookmarkItem {
 	file: TFile;
@@ -53,6 +62,12 @@ export class BookmarkView extends ItemView {
 	private typeFilter = "";
 	private favoritesOnly = false;
 	private brokenOnly = false;
+	/** Landing shows category tiles; entering one switches to the card grid. */
+	private viewMode: "categories" | "cards" = "categories";
+	/** The category (folder, "" = Uncategorized) entered from a tile, else null. */
+	private activeCategory: string | null = null;
+	/** When inside a category, whether search/filters span all bookmarks or just that category. */
+	private searchScope: "global" | "category" = "category";
 	/** Whether the (potentially large) tag filter panel is expanded. */
 	private tagsExpanded = false;
 	/** Tag panel sort order: by assignment count (default) or alphabetical. */
@@ -122,6 +137,13 @@ export class BookmarkView extends ItemView {
 		// explicit rebuild (Refresh button, filter/domain/related change). Stale paths
 		// are harmless: getSelectedFiles() resolves against the current item set.
 		this.loadBookmarks();
+		// The category landing has no grid/selection to preserve; redraw it in place.
+		if (this.viewMode === "categories" && !this.domainFilter && !this.relatedTo) {
+			this.contentEl.empty();
+			this.contentEl.addClass("bookmarker-board");
+			this.renderCategories();
+			return;
+		}
 		// Leave related mode if its source bookmark was deleted.
 		const related = this.relatedTo;
 		if (related && !this.items.some((i) => i.file.path === related.file.path)) {
@@ -139,6 +161,7 @@ export class BookmarkView extends ItemView {
 	/** Filter the board to a single domain (www-insensitive) and redraw. */
 	filterByDomain(domain: string): void {
 		this.domainFilter = domain.toLowerCase().replace(/^www\./, "");
+		this.viewMode = "cards";
 		this.rebuild();
 	}
 
@@ -152,27 +175,134 @@ export class BookmarkView extends ItemView {
 		return this.filtered().map((i) => i.file);
 	}
 
-	/** Full rebuild: re-scan the vault and redraw toolbar + grid. */
+	/** Full rebuild: re-scan the vault and redraw the active view (categories or cards). */
 	private rebuild(): void {
 		this.selected.clear();
 		this.contentEl.empty();
 		this.contentEl.addClass("bookmarker-board");
 		this.loadBookmarks();
+		// Domain/related drilldowns are inherently card views; force cards mode for them.
+		if (this.viewMode === "categories" && !this.domainFilter && !this.relatedTo) {
+			this.renderCategories();
+			return;
+		}
 		this.renderToolbar();
 		this.gridEl = this.contentEl.createDiv({ cls: "bookmarker-grid" });
 		this.applyCardSize();
 		this.renderGrid();
 	}
 
+	/** Minimum grid column width for the chosen card size. */
+	private cardMin(): string {
+		return this.plugin.settings.cardSize === "small"
+			? "160px"
+			: this.plugin.settings.cardSize === "large"
+				? "300px"
+				: "220px";
+	}
+
 	/** Drive the grid's minimum column width from the chosen card size. */
 	private applyCardSize(): void {
-		const min =
-			this.plugin.settings.cardSize === "small"
-				? "160px"
-				: this.plugin.settings.cardSize === "large"
-					? "300px"
-					: "220px";
-		this.gridEl.setCssProps({ "--bm-card-min": min });
+		this.gridEl.setCssProps({ "--bm-card-min": this.cardMin() });
+	}
+
+	/**
+	 * Category landing: a tile per subfolder of the root ("" = Uncategorized), so the board
+	 * opens without loading every card. Each tile carries a customizable color and icon and
+	 * drills into the cards view scoped to that category.
+	 */
+	private renderCategories(): void {
+		const header = this.contentEl.createDiv({ cls: "bookmarker-toolbar" });
+		header.createSpan({ cls: "bookmarker-board-title", text: "Categories" });
+
+		const searchInput = header.createEl("input", {
+			cls: "bookmarker-search",
+			attr: { type: "search", placeholder: "Search all bookmarks…" },
+		});
+		// Searching from the landing drops straight into a global card view.
+		searchInput.addEventListener("input", () => {
+			const query = searchInput.value.toLowerCase().trim();
+			if (!query) return;
+			this.search = query;
+			this.searchScope = "global";
+			this.activeCategory = null;
+			this.viewMode = "cards";
+			this.rebuild();
+		});
+
+		const refresh = header.createEl("button", { cls: "bookmarker-toolbar-btn", text: "Refresh" });
+		refresh.addEventListener("click", () => this.rebuild());
+
+		const counts = new Map<string, number>();
+		for (const item of this.items) {
+			counts.set(item.folder, (counts.get(item.folder) ?? 0) + 1);
+		}
+
+		const grid = this.contentEl.createDiv({ cls: "bookmarker-category-grid" });
+		grid.setCssProps({ "--bm-card-min": this.cardMin() });
+		if (counts.size === 0) {
+			grid.createDiv({
+				cls: "bookmarker-empty",
+				text: this.items.length ? "No categories." : "No bookmarks yet.",
+			});
+			return;
+		}
+
+		// Named categories alphabetically; Uncategorized ("") always last.
+		const categories = [...counts.keys()].sort(
+			(a, b) => Number(a === "") - Number(b === "") || a.localeCompare(b),
+		);
+		for (const category of categories) {
+			this.renderCategoryTile(grid, category, counts.get(category) ?? 0);
+		}
+	}
+
+	private renderCategoryTile(grid: HTMLElement, category: string, count: number): void {
+		const style = this.plugin.settings.categoryStyles[category] ?? { color: "", icon: "" };
+		const tile = grid.createDiv({ cls: "bookmarker-category-tile" });
+		if (style.color) tile.setCssProps({ "--bm-cat-color": style.color });
+
+		const iconEl = tile.createSpan({ cls: "bookmarker-category-icon" });
+		renderCategoryIcon(iconEl, style.icon || "folder");
+
+		const body = tile.createDiv({ cls: "bookmarker-category-body" });
+		body.createDiv({ cls: "bookmarker-category-name", text: category || "Uncategorized" });
+		body.createDiv({
+			cls: "bookmarker-category-count",
+			text: `${count} bookmark${count === 1 ? "" : "s"}`,
+		});
+
+		const edit = tile.createSpan({
+			cls: "bookmarker-category-edit",
+			text: "✎",
+			attr: { "aria-label": "Edit category color and icon", title: "Edit category color and icon" },
+		});
+		edit.addEventListener("click", (event) => {
+			event.stopPropagation();
+			this.editCategoryStyle(category);
+		});
+
+		tile.addEventListener("click", () => {
+			this.activeCategory = category;
+			this.searchScope = "category";
+			this.viewMode = "cards";
+			this.rebuild();
+		});
+	}
+
+	private editCategoryStyle(category: string): void {
+		const current = this.plugin.settings.categoryStyles[category] ?? { color: "", icon: "" };
+		new CategoryStyleModal(this.app, {
+			category: category || "Uncategorized",
+			color: current.color,
+			icon: current.icon,
+			onSave: (color, icon) => {
+				if (!color && !icon) delete this.plugin.settings.categoryStyles[category];
+				else this.plugin.settings.categoryStyles[category] = { color, icon };
+				void this.plugin.saveSettings();
+				this.rebuild();
+			},
+		}).open();
 	}
 
 	private loadBookmarks(): void {
@@ -205,6 +335,32 @@ export class BookmarkView extends ItemView {
 
 	private renderToolbar(): void {
 		const toolbar = this.contentEl.createDiv({ cls: "bookmarker-toolbar" });
+
+		const back = toolbar.createEl("button", {
+			cls: "bookmarker-toolbar-btn",
+			text: "← Categories",
+		});
+		back.addEventListener("click", () => {
+			this.viewMode = "categories";
+			this.activeCategory = null;
+			this.domainFilter = "";
+			this.relatedTo = null;
+			this.search = "";
+			this.rebuild();
+		});
+
+		// Scope toggle: search/filter within the entered category, or across all bookmarks.
+		if (this.activeCategory !== null) {
+			const label = this.activeCategory || "Uncategorized";
+			const scopeSel = toolbar.createEl("select", { cls: "bookmarker-scope-select" });
+			scopeSel.createEl("option", { value: "category", text: `In "${label}"` });
+			scopeSel.createEl("option", { value: "global", text: "All bookmarks" });
+			scopeSel.value = this.searchScope;
+			scopeSel.addEventListener("change", () => {
+				this.searchScope = scopeSel.value === "global" ? "global" : "category";
+				this.renderGrid();
+			});
+		}
 
 		if (this.domainFilter) {
 			const chip = toolbar.createSpan({
@@ -499,6 +655,14 @@ export class BookmarkView extends ItemView {
 		// Fuzzy match (typo/word-order tolerant) over title, domain, url, tags, description.
 		const matcher = this.search ? prepareFuzzySearch(this.search) : null;
 		return this.items.filter((item) => {
+			// Category scope: constrain to the entered category unless scope is global.
+			if (
+				this.searchScope === "category" &&
+				this.activeCategory !== null &&
+				item.folder !== this.activeCategory
+			) {
+				return false;
+			}
 			if (
 				this.domainFilter &&
 				item.domain.toLowerCase().replace(/^www\./, "") !== this.domainFilter
@@ -673,6 +837,7 @@ export class BookmarkView extends ItemView {
 	/** Enter related mode: the board shows the bookmarks related to this one. */
 	private showRelated(item: BookmarkItem): void {
 		this.relatedTo = item;
+		this.viewMode = "cards";
 		this.rebuild();
 	}
 

--- a/src/category-style-modal.ts
+++ b/src/category-style-modal.ts
@@ -1,0 +1,123 @@
+import { App, Modal, Setting, setIcon } from "obsidian";
+
+interface CategoryStyleOptions {
+	/** Display name of the category ("Uncategorized" for root-level bookmarks). */
+	category: string;
+	color: string;
+	icon: string;
+	onSave: (color: string, icon: string) => void;
+}
+
+/** Theme-friendly swatches offered for a category accent color. */
+const SWATCHES = [
+	"#e5534b",
+	"#d9730d",
+	"#dfab01",
+	"#49852e",
+	"#2f9e9e",
+	"#4f7cd9",
+	"#9a5cd0",
+	"#c2557f",
+];
+
+/**
+ * Pick a color and an icon for a category tile. The icon accepts either an emoji
+ * or a Lucide icon name; the preview reflects whichever the field resolves to.
+ */
+export class CategoryStyleModal extends Modal {
+	private readonly opts: CategoryStyleOptions;
+	private color: string;
+	private icon: string;
+	private previewEl: HTMLElement | null = null;
+
+	constructor(app: App, opts: CategoryStyleOptions) {
+		super(app);
+		this.opts = opts;
+		this.color = opts.color;
+		this.icon = opts.icon;
+	}
+
+	onOpen(): void {
+		const { contentEl } = this;
+		contentEl.createEl("h2", { text: `Category "${this.opts.category}"` });
+
+		const preview = contentEl.createDiv({ cls: "bookmarker-category-preview" });
+		this.previewEl = preview.createSpan({ cls: "bookmarker-category-icon" });
+		this.updatePreview();
+
+		new Setting(contentEl)
+			.setName("Icon")
+			.setDesc("An emoji or a Lucide icon name (e.g. shopping-cart).")
+			.addText((text) => {
+				text
+					.setPlaceholder("🛒 or shopping-cart")
+					.setValue(this.icon)
+					.onChange((value) => {
+						this.icon = value.trim();
+						this.updatePreview();
+					});
+			});
+
+		const colorSetting = new Setting(contentEl).setName("Color");
+		const swatches = colorSetting.controlEl.createDiv({ cls: "bookmarker-color-swatches" });
+		const mark = (selected: HTMLElement): void => {
+			swatches
+				.querySelectorAll(".bookmarker-color-swatch")
+				.forEach((el) => el.removeClass("is-selected"));
+			selected.addClass("is-selected");
+		};
+		for (const value of SWATCHES) {
+			const swatch = swatches.createSpan({ cls: "bookmarker-color-swatch" });
+			swatch.setCssProps({ "--bm-swatch": value });
+			if (value === this.color) swatch.addClass("is-selected");
+			swatch.addEventListener("click", () => {
+				this.color = value;
+				mark(swatch);
+				this.updatePreview();
+			});
+		}
+		const none = swatches.createSpan({
+			cls: "bookmarker-color-swatch bookmarker-color-none",
+			text: "None",
+		});
+		if (!this.color) none.addClass("is-selected");
+		none.addEventListener("click", () => {
+			this.color = "";
+			mark(none);
+			this.updatePreview();
+		});
+
+		new Setting(contentEl)
+			.addButton((button) =>
+				button
+					.setButtonText("Save")
+					.setCta()
+					.onClick(() => {
+						this.close();
+						this.opts.onSave(this.color, this.icon);
+					}),
+			)
+			.addButton((button) =>
+				button.setButtonText("Reset").onClick(() => {
+					this.close();
+					this.opts.onSave("", "");
+				}),
+			)
+			.addButton((button) => button.setButtonText("Cancel").onClick(() => this.close()));
+	}
+
+	onClose(): void {
+		this.contentEl.empty();
+	}
+
+	/** Render the chosen icon (Lucide or emoji) tinted with the chosen color. */
+	private updatePreview(): void {
+		const el = this.previewEl;
+		if (!el) return;
+		el.empty();
+		el.setCssProps({ "--bm-cat-color": this.color || "var(--text-normal)" });
+		const value = this.icon || "folder";
+		setIcon(el, value);
+		if (!el.querySelector("svg")) el.setText(value);
+	}
+}

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -24,6 +24,8 @@ export interface BookmarkerSettings {
 	brokenFolderName: string;
 	brokenDefaultRemediation: "wayback" | "move" | "mark";
 	cardSize: "small" | "medium" | "large";
+	/** Per-category color + icon for the category landing tiles, keyed by folder name ("" = Uncategorized). */
+	categoryStyles: Record<string, { color: string; icon: string }>;
 }
 
 export const DEFAULT_SETTINGS: BookmarkerSettings = {
@@ -47,6 +49,7 @@ export const DEFAULT_SETTINGS: BookmarkerSettings = {
 	brokenFolderName: "_broken",
 	brokenDefaultRemediation: "mark",
 	cardSize: "medium",
+	categoryStyles: {},
 };
 
 export class BookmarkerSettingTab extends PluginSettingTab {

--- a/styles.css
+++ b/styles.css
@@ -219,6 +219,129 @@
 	gap: var(--size-4-3);
 }
 
+.bookmarker-board-title {
+	font-weight: var(--font-semibold);
+	font-size: var(--font-ui-medium);
+}
+
+.bookmarker-category-grid {
+	display: grid;
+	grid-template-columns: repeat(auto-fill, minmax(var(--bm-card-min, 220px), 1fr));
+	gap: var(--size-4-3);
+}
+
+.bookmarker-category-tile {
+	position: relative;
+	display: flex;
+	align-items: center;
+	gap: var(--size-4-2);
+	padding: var(--size-4-3);
+	border: 1px solid var(--background-modifier-border);
+	border-left: 4px solid var(--bm-cat-color, var(--background-modifier-border));
+	border-radius: var(--radius-m);
+	background: var(--background-secondary);
+	cursor: pointer;
+	transition: border-color 0.1s ease;
+}
+
+.bookmarker-category-tile:hover {
+	border-color: var(--interactive-accent);
+}
+
+.bookmarker-category-icon {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	width: 24px;
+	height: 24px;
+	font-size: 20px;
+	line-height: 1;
+	color: var(--bm-cat-color, var(--text-normal));
+}
+
+.bookmarker-category-icon svg {
+	width: 22px;
+	height: 22px;
+}
+
+.bookmarker-category-body {
+	display: flex;
+	flex-direction: column;
+	min-width: 0;
+}
+
+.bookmarker-category-name {
+	font-weight: var(--font-semibold);
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+}
+
+.bookmarker-category-count {
+	color: var(--text-muted);
+	font-size: var(--font-ui-smaller);
+}
+
+.bookmarker-category-edit {
+	position: absolute;
+	top: var(--size-2-2);
+	right: var(--size-2-2);
+	cursor: pointer;
+	opacity: 0.5;
+	font-size: var(--font-ui-smaller);
+}
+
+.bookmarker-category-edit:hover {
+	opacity: 1;
+}
+
+.bookmarker-category-preview {
+	display: flex;
+	justify-content: center;
+	margin-bottom: var(--size-4-3);
+}
+
+.bookmarker-category-preview .bookmarker-category-icon {
+	width: 40px;
+	height: 40px;
+	font-size: 34px;
+}
+
+.bookmarker-category-preview .bookmarker-category-icon svg {
+	width: 36px;
+	height: 36px;
+}
+
+.bookmarker-color-swatches {
+	display: flex;
+	flex-wrap: wrap;
+	gap: var(--size-2-2);
+	align-items: center;
+}
+
+.bookmarker-color-swatch {
+	width: 22px;
+	height: 22px;
+	border-radius: 50%;
+	background: var(--bm-swatch);
+	cursor: pointer;
+	border: 2px solid transparent;
+}
+
+.bookmarker-color-swatch.is-selected {
+	border-color: var(--text-normal);
+}
+
+.bookmarker-color-none {
+	width: auto;
+	height: auto;
+	padding: 2px 8px;
+	border-radius: var(--radius-s);
+	background: var(--background-modifier-border);
+	color: var(--text-muted);
+	font-size: var(--font-ui-smaller);
+}
+
 .bookmarker-card {
 	position: relative;
 	display: flex;


### PR DESCRIPTION
Open the board on a grid of category tiles (the subfolders of `_bookmarks`, plus Uncategorized for root-level bookmarks) instead of loading every card at once. Each tile shows a count and a customizable color and icon (emoji or Lucide name) and drills into the cards of that category. A scope selector switches search and filters between the current category and all bookmarks.

## Changes
- `src/settings.ts`: `categoryStyles` setting (per-category color + icon, persisted).
- `src/category-style-modal.ts` (new): color swatch + icon picker (emoji or Lucide name) with live preview.
- `src/bookmark-view.ts`: `viewMode` (categories landing default), `renderCategories()` + tiles, `activeCategory`/`searchScope` with scope selector and `← Categories` back control, per-tile edit pencil, category scoping in `filtered()`. Icons via `setIcon` with emoji fallback; colors applied with `setCssProps` (lint-safe).
- `styles.css`: category grid/tile, icon, color accent, swatches, scope select.

Build green, `tsc` clean, ESLint clean.

Designed and implemented via the concept-to-code Express chain.