### PR TITLE
feat(board): scale card height with size, add view switch and icon palette

### DIFF
--- a/src/bookmark-view.ts
+++ b/src/bookmark-view.ts
@@ -194,16 +194,28 @@ export class BookmarkView extends ItemView {
 
 	/** Minimum grid column width for the chosen card size. */
 	private cardMin(): string {
-		return this.plugin.settings.cardSize === "small"
-			? "160px"
-			: this.plugin.settings.cardSize === "large"
-				? "300px"
-				: "220px";
+		return this.sizeVars()["--bm-card-min"];
 	}
 
-	/** Drive the grid's minimum column width from the chosen card size. */
+	/** Grid CSS variables for the chosen card size: column width plus title/tag scale. */
+	private sizeVars(): Record<string, string> {
+		switch (this.plugin.settings.cardSize) {
+			case "small":
+				return { "--bm-card-min": "160px", "--bm-card-title": "0.85em", "--bm-card-tag": "0.7em" };
+			case "large":
+				return { "--bm-card-min": "300px", "--bm-card-title": "1.2em", "--bm-card-tag": "0.85em" };
+			default:
+				return {
+					"--bm-card-min": "220px",
+					"--bm-card-title": "1em",
+					"--bm-card-tag": "var(--font-ui-smaller)",
+				};
+		}
+	}
+
+	/** Drive the grid's column width and title/tag scale from the chosen card size. */
 	private applyCardSize(): void {
-		this.gridEl.setCssProps({ "--bm-card-min": this.cardMin() });
+		this.gridEl.setCssProps(this.sizeVars());
 	}
 
 	/**
@@ -214,6 +226,19 @@ export class BookmarkView extends ItemView {
 	private renderCategories(): void {
 		const header = this.contentEl.createDiv({ cls: "bookmarker-toolbar" });
 		header.createSpan({ cls: "bookmarker-board-title", text: "Categories" });
+
+		// Switch straight to the full card grid (all bookmarks, no category scope).
+		const allCards = header.createEl("button", {
+			cls: "bookmarker-toolbar-btn",
+			text: "▦ All cards",
+		});
+		allCards.addEventListener("click", () => {
+			this.viewMode = "cards";
+			this.activeCategory = null;
+			this.searchScope = "global";
+			this.search = "";
+			this.rebuild();
+		});
 
 		const searchInput = header.createEl("input", {
 			cls: "bookmarker-search",

--- a/src/category-style-modal.ts
+++ b/src/category-style-modal.ts
@@ -1,4 +1,4 @@
-import { App, Modal, Setting, setIcon } from "obsidian";
+import { App, Modal, Setting, TextComponent, setIcon } from "obsidian";
 
 interface CategoryStyleOptions {
 	/** Display name of the category ("Uncategorized" for root-level bookmarks). */
@@ -21,14 +21,75 @@ const SWATCHES = [
 ];
 
 /**
- * Pick a color and an icon for a category tile. The icon accepts either an emoji
- * or a Lucide icon name; the preview reflects whichever the field resolves to.
+ * A broad set of Lucide icon names to pick from. Names that the running Obsidian
+ * build does not ship are filtered out at render time, so the palette stays valid
+ * across versions without a hard dependency on a specific Lucide release.
+ */
+const ICON_CANDIDATES = [
+	"folder", "folder-open", "folder-heart", "folder-git-2", "file", "file-text", "files",
+	"bookmark", "book", "book-open", "library", "newspaper", "sticky-note", "clipboard",
+	"list", "list-checks", "layout-grid", "layout-list", "columns", "table",
+	"star", "heart", "flag", "tag", "tags", "hash", "bell", "inbox", "mail", "send",
+	"message-circle", "message-square", "phone", "at-sign",
+	"home", "building", "building-2", "factory", "store", "warehouse", "school",
+	"landmark", "church", "castle", "hotel",
+	"briefcase", "calendar", "calendar-days", "calendar-check", "clock", "alarm-clock",
+	"timer", "hourglass", "history",
+	"search", "filter", "settings", "sliders-horizontal", "wrench", "hammer", "cog",
+	"plug", "power",
+	"cpu", "database", "server", "hard-drive", "save", "download", "upload", "cloud",
+	"archive", "trash-2",
+	"lock", "unlock", "key", "shield", "shield-check", "eye", "eye-off", "fingerprint",
+	"camera", "image", "images", "film", "video", "clapperboard", "music", "headphones",
+	"mic", "speaker", "volume-2", "radio", "podcast", "disc",
+	"monitor", "smartphone", "tablet", "laptop", "tv", "printer", "mouse", "keyboard",
+	"gamepad-2", "joystick", "webcam",
+	"wifi", "bluetooth", "signal", "battery", "zap", "flashlight",
+	"sun", "moon", "cloud-rain", "cloud-snow", "umbrella", "snowflake", "droplet", "wind",
+	"thermometer", "sunrise", "sunset", "rainbow",
+	"leaf", "tree-pine", "trees", "flower", "sprout", "clover", "mountain", "waves",
+	"tent", "palmtree",
+	"coffee", "cup-soda", "utensils", "pizza", "beef", "salad", "apple", "cherry",
+	"ice-cream", "cookie", "wine", "beer", "martini", "candy", "cake", "croissant",
+	"egg", "fish", "carrot", "wheat",
+	"car", "bus", "train-front", "plane", "ship", "sailboat", "bike", "rocket", "fuel",
+	"anchor", "compass", "map", "map-pin", "navigation", "globe", "route", "footprints",
+	"luggage",
+	"dices", "puzzle", "swords", "trophy", "medal", "award", "target", "crosshair",
+	"dumbbell",
+	"palette", "brush", "paintbrush", "pen-tool", "pencil", "pen", "highlighter",
+	"eraser", "scissors", "ruler", "shapes", "sticker", "stamp", "type",
+	"graduation-cap", "presentation", "microscope", "telescope", "atom", "flask-conical",
+	"test-tube", "dna", "calculator", "binary", "sigma", "infinity", "brain", "lightbulb",
+	"users", "user", "user-check", "smile", "frown", "laugh", "thumbs-up", "thumbs-down",
+	"hand", "handshake", "baby", "accessibility",
+	"heart-pulse", "activity", "trending-up", "bar-chart-3", "line-chart", "pie-chart",
+	"gauge", "scale",
+	"dollar-sign", "euro", "bitcoin", "credit-card", "wallet", "banknote", "coins",
+	"piggy-bank", "receipt", "percent", "shopping-cart", "shopping-bag", "package",
+	"truck", "box", "boxes", "gift", "ticket",
+	"github", "git-branch", "git-merge", "git-pull-request", "code", "terminal", "braces",
+	"bug", "command", "container", "blocks", "component", "webhook", "qr-code",
+	"link", "external-link", "share-2", "rss", "paperclip",
+	"flame", "sparkles", "party-popper", "gem", "crown", "diamond", "feather", "ghost",
+	"skull", "bot",
+	"shirt", "glasses", "watch", "dog", "cat", "bird", "rabbit", "turtle", "snail",
+	"pill", "stethoscope", "syringe", "bandage", "cross", "heart-handshake",
+	"axe", "pickaxe", "shovel",
+];
+
+/**
+ * Pick a color and an icon for a category tile. The icon can be chosen from the
+ * built-in palette or typed directly (an emoji or any Lucide name); the preview
+ * reflects whichever the field resolves to.
  */
 export class CategoryStyleModal extends Modal {
 	private readonly opts: CategoryStyleOptions;
 	private color: string;
 	private icon: string;
 	private previewEl: HTMLElement | null = null;
+	private iconInput: TextComponent | null = null;
+	private paletteEl: HTMLElement | null = null;
 
 	constructor(app: App, opts: CategoryStyleOptions) {
 		super(app);
@@ -47,14 +108,16 @@ export class CategoryStyleModal extends Modal {
 
 		new Setting(contentEl)
 			.setName("Icon")
-			.setDesc("An emoji or a Lucide icon name (e.g. shopping-cart).")
+			.setDesc("Pick one below, or type an emoji or a Lucide icon name.")
 			.addText((text) => {
+				this.iconInput = text;
 				text
 					.setPlaceholder("🛒 or shopping-cart")
 					.setValue(this.icon)
 					.onChange((value) => {
 						this.icon = value.trim();
 						this.updatePreview();
+						this.markSelectedIcon();
 					});
 			});
 
@@ -87,6 +150,14 @@ export class CategoryStyleModal extends Modal {
 			this.updatePreview();
 		});
 
+		const filter = contentEl.createEl("input", {
+			cls: "bookmarker-icon-filter",
+			attr: { type: "search", placeholder: "Filter icons…" },
+		});
+		this.paletteEl = contentEl.createDiv({ cls: "bookmarker-icon-palette" });
+		this.buildPalette("");
+		filter.addEventListener("input", () => this.buildPalette(filter.value.toLowerCase().trim()));
+
 		new Setting(contentEl)
 			.addButton((button) =>
 				button
@@ -108,6 +179,39 @@ export class CategoryStyleModal extends Modal {
 
 	onClose(): void {
 		this.contentEl.empty();
+	}
+
+	/** Render the icon palette, skipping names the running Lucide build does not provide. */
+	private buildPalette(needle: string): void {
+		const palette = this.paletteEl;
+		if (!palette) return;
+		palette.empty();
+		for (const name of ICON_CANDIDATES) {
+			if (needle && !name.includes(needle)) continue;
+			const option = palette.createSpan({
+				cls: "bookmarker-icon-option",
+				attr: { "aria-label": name, title: name },
+			});
+			setIcon(option, name);
+			if (!option.querySelector("svg")) {
+				option.remove();
+				continue;
+			}
+			if (name === this.icon) option.addClass("is-selected");
+			option.addEventListener("click", () => {
+				this.icon = name;
+				this.iconInput?.setValue(name);
+				this.updatePreview();
+				this.markSelectedIcon();
+			});
+		}
+	}
+
+	/** Sync the palette highlight with the current icon value. */
+	private markSelectedIcon(): void {
+		this.paletteEl?.querySelectorAll(".bookmarker-icon-option").forEach((el) => {
+			el.toggleClass("is-selected", el.getAttr("aria-label") === this.icon);
+		});
 	}
 
 	/** Render the chosen icon (Lucide or emoji) tinted with the chosen color. */

--- a/styles.css
+++ b/styles.css
@@ -217,6 +217,9 @@
 	display: grid;
 	grid-template-columns: repeat(auto-fill, minmax(var(--bm-card-min, 220px), 1fr));
 	gap: var(--size-4-3);
+	/* Each card hugs its own content instead of stretching to the tallest in the row,
+	   so smaller sizes are genuinely shorter rather than padded with empty space. */
+	align-items: start;
 }
 
 .bookmarker-board-title {
@@ -342,6 +345,47 @@
 	font-size: var(--font-ui-smaller);
 }
 
+.bookmarker-icon-filter {
+	width: 100%;
+	margin-top: var(--size-4-2);
+}
+
+.bookmarker-icon-palette {
+	display: flex;
+	flex-wrap: wrap;
+	gap: var(--size-2-1);
+	margin-top: var(--size-2-2);
+	max-height: 12rem;
+	overflow-y: auto;
+}
+
+.bookmarker-icon-option {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	width: 32px;
+	height: 32px;
+	border-radius: var(--radius-s);
+	cursor: pointer;
+	color: var(--text-muted);
+}
+
+.bookmarker-icon-option:hover {
+	background: var(--background-modifier-hover);
+	color: var(--text-normal);
+}
+
+.bookmarker-icon-option.is-selected {
+	background: var(--background-modifier-hover);
+	color: var(--interactive-accent);
+	outline: 1px solid var(--interactive-accent);
+}
+
+.bookmarker-icon-option svg {
+	width: 18px;
+	height: 18px;
+}
+
 .bookmarker-card {
 	position: relative;
 	display: flex;
@@ -424,6 +468,7 @@
 
 .bookmarker-card-title {
 	font-weight: var(--font-semibold);
+	font-size: var(--bm-card-title, 1em);
 	padding: var(--size-4-2) var(--size-4-2) 0;
 	line-height: 1.3;
 }
@@ -439,6 +484,10 @@
 	flex-wrap: wrap;
 	gap: var(--size-2-1);
 	padding: var(--size-2-2) var(--size-4-2) var(--size-4-2);
+}
+
+.bookmarker-card-tags .bookmarker-tag-chip {
+	font-size: var(--bm-card-tag, var(--font-ui-smaller));
 }
 
 .bookmarker-empty {


### PR DESCRIPTION
Three board refinements on top of 0.1.18:

- **Card height scales with size.** The grid uses `align-items: start` so each card hugs its content instead of stretching to the tallest in the row (removing the empty space under short cards), and title/tag text scale via `--bm-card-title`/`--bm-card-tag` set per size.
- **View switch.** An `▦ All cards` button on the category landing jumps straight to the full card grid; the existing `← Categories` returns. Both views are reachable directly.
- **Built-in icon palette.** The category style dialog now shows a filterable grid of Lucide icons (200+ candidates, runtime-filtered to those the running Obsidian build ships), so an icon is picked by click. The text field still accepts an emoji or custom name.

Build green, `tsc` clean, ESLint clean.