### PR TITLE
feat(board): add a toolbar toggle to use the file name as card title

### DIFF
--- a/src/bookmark-view.ts
+++ b/src/bookmark-view.ts
@@ -357,7 +357,9 @@ export class BookmarkView extends ItemView {
 			const parent = file.parent?.path ?? "";
 			items.push({
 				file,
-				title: asString(fm.title) || file.basename,
+				title: this.plugin.settings.useFileNameAsTitle
+					? file.basename
+					: asString(fm.title) || file.basename,
 				url: asString(fm.url),
 				image: asString(fm.image),
 				tags: normalizeTags(fm.tags),
@@ -536,6 +538,17 @@ export class BookmarkView extends ItemView {
 				mode === "modified" || mode === "az" || mode === "za" ? mode : "added";
 			void this.plugin.saveSettings();
 			this.renderGrid();
+		});
+
+		// Quick toggle: card title source (frontmatter title vs file name).
+		const titleSrc = toolbar.createEl("button", {
+			cls: "bookmarker-toolbar-btn",
+			text: this.plugin.settings.useFileNameAsTitle ? "Title: file name" : "Title: metadata",
+		});
+		titleSrc.addEventListener("click", () => {
+			this.plugin.settings.useFileNameAsTitle = !this.plugin.settings.useFileNameAsTitle;
+			void this.plugin.saveSettings();
+			this.rebuild();
 		});
 
 		const refresh = toolbar.createEl("button", {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -26,6 +26,8 @@ export interface BookmarkerSettings {
 	cardSize: "small" | "medium" | "large";
 	/** Card ordering: by added date, modified date, or title ascending/descending. */
 	sortMode: "added" | "modified" | "az" | "za";
+	/** Show the file name (basename) as the card title instead of the frontmatter title. */
+	useFileNameAsTitle: boolean;
 	/** Per-category color + icon for the category landing tiles, keyed by folder name ("" = Uncategorized). */
 	categoryStyles: Record<string, { color: string; icon: string }>;
 }
@@ -52,6 +54,7 @@ export const DEFAULT_SETTINGS: BookmarkerSettings = {
 	brokenDefaultRemediation: "mark",
 	cardSize: "medium",
 	sortMode: "added",
+	useFileNameAsTitle: false,
 	categoryStyles: {},
 };
 


### PR DESCRIPTION
Add a toolbar button that switches the card title between the frontmatter title and the file name. When the file name is chosen, renaming the note updates the card right away, keeping the title and the file in sync. The choice is saved and also drives search and alphabetical sort. The frontmatter title stays the default.

## Changes
- `src/settings.ts`: `useFileNameAsTitle` setting (default `false`).
- `src/bookmark-view.ts`: `loadBookmarks` derives the title from `file.basename` when the toggle is on; new `Title: metadata / file name` toolbar button flips it, saves, and rebuilds.

Build green, `tsc` clean, ESLint clean.