### PR TITLE
feat(board): add hide-bookmarks toolbar toggle and context-menu action

### DIFF
--- a/docs/architecture/ADR-002-hide-bookmarks.md
+++ b/docs/architecture/ADR-002-hide-bookmarks.md
@@ -1,0 +1,144 @@
+# ADR-002 — Per-note hide flag with in-memory show-hidden toggle
+
+## Status
+
+Accepted — 2026-06-16
+
+## Context
+
+The board (`BookmarkView`) already supports `favorite` and `broken` as optional
+boolean frontmatter flags on each note. Both are read in `loadBookmarks`, stored
+in `BookmarkItem`, and drive `filtered()` and per-card badges. The toolbar has
+toggle chips (`bookmarker-tag-chip` + `bookmarker-tag-active`) and a conditional
+bulk-action button (`deleteBrokenBtn`, toggled via `bookmarker-hidden`) as
+established patterns.
+
+The user needs a way to keep certain bookmarks in the vault but exclude them from
+the board by default, revealing them on demand. The SPEC requires:
+
+- A `hidden` frontmatter flag (absent/false = visible, true = hidden).
+- A per-card context-menu action to hide or unhide.
+- A bulk "Hide selected" toolbar button (shown only when selection is non-empty).
+- A toolbar chip "Show hidden" (in-memory, default off) that includes hidden cards
+  dimmed and badged when on.
+- Consistent exclusion: grid, count label, search results, and category counts
+  all respect the visibility rule while the toggle is off.
+
+Constraints: TypeScript, Obsidian vault API only, mobile-safe (no Node modules,
+no inline `.style` assignments per the `obsidianmd/no-static-styles-assignment`
+lint rule), no persisted settings change.
+
+## Decision
+
+Extend `BookmarkItem` with `hidden: boolean`, read in `loadBookmarks` as
+`fm.hidden === true` (mirrors `favorite`/`broken`). Add `showHidden: boolean`
+in-memory field on `BookmarkView`, default `false`.
+
+**Filter gate:** `filtered()` prepends the rule
+`if (item.hidden && !this.showHidden) return false` before all other predicates.
+This single gate covers grid rendering, the count label, search, folder/tag
+filters, and `getVisibleFiles()`.
+
+**Category counts:** `renderCategories()` currently counts `this.items` directly.
+Change the loop to filter out hidden items when `showHidden` is false, so
+category tile counts match the grid.
+
+**Toolbar additions (inside `renderToolbar()`):**
+1. "Show hidden" chip, styled as `bookmarker-tag-chip`, active class toggled
+   on click, calls `renderGrid()`. Declared after the existing Broken chip.
+2. "Hide selected" button, a `bookmarker-toolbar-btn` with an error-coloured
+   class (same pattern as `deleteBrokenBtn`), stored as `hideSelectedBtn`.
+   Its visibility is driven by `toggleClass("bookmarker-hidden", ...)` in
+   `renderGrid()`, alongside `deleteBrokenBtn`, whenever
+   `this.selected.size > 0`.
+
+**Context menu (inside `showCardMenu()`):** a new entry immediately before the
+existing "Delete" separator. It reads "Hide" when `!item.hidden`, "Unhide" when
+`item.hidden`. The handler calls `processFrontMatter` to write `hidden: true` or
+deletes the key (sets to undefined/null so the key is removed cleanly), updates
+`item.hidden` in memory, and calls `renderGrid()`.
+
+**Bulk hide (new private method `hideSelected()`):** iterates
+`this.items.filter(i => this.selected.has(i.file.path))`, writes
+`fm.hidden = true` via `processFrontMatter` on each, clears selection, calls
+`renderGrid()`. Idempotent: already-hidden items are written again harmlessly.
+
+**Visual treatment when shown:** in `renderCard()`, when `item.hidden &&
+this.showHidden`, add class `bookmarker-card--hidden` to the card element. CSS
+gives that class `opacity: 0.45`. A `<span class="bookmarker-card-hidden-badge">`
+sits on the cover (same absolute-position pattern as `bookmarker-card-broken`).
+
+All CSS is in `styles.css` (no inline style assignments).
+
+## Alternatives considered
+
+### A: Persist the toggle in `BookmarkerSettings`
+
+Store `showHidden: boolean` in `DEFAULT_SETTINGS` and `BookmarkerSettings`.
+Pros: state survives across vault reopens.
+Rejected: the SPEC explicitly says "not persisted" and "every time the board
+opens it starts with hidden bookmarks excluded". Persisting it would silently
+reveal a set of items the user intentionally hid, undermining the purpose of the
+feature. The in-memory default-off behaviour is the whole point.
+
+### B: Filter hidden items at load time (`loadBookmarks`) rather than at `filtered()`
+
+Omit hidden items from `this.items` entirely when `showHidden` is false, so
+`filtered()`, category counts, and `getVisibleFiles()` all see the smaller set
+without explicit checks.
+Pros: no per-call guard in `filtered()`.
+Cons: the toggle would require calling `loadBookmarks()` + full redraw (the vault
+scan) on every toggle click, not just `renderGrid()`. It also makes
+`getSelectedFiles()` silently drop hidden paths from the selection when the
+toggle is off, making "Hide selected" unreachable for already-hidden items in the
+selection. The `filtered()` gate is the established pattern (see `favoritesOnly`,
+`brokenOnly`) and costs one boolean check per item.
+Rejected: rebuild-on-toggle cost and selection coherence issue outweigh the
+marginal simplicity gain.
+
+### C: Separate "hidden" view mode instead of a toggle
+
+Replace the toggle with a dedicated board mode ("Hidden" chip on the categories
+landing) that shows only hidden items, symmetrical to the existing Favorites and
+Broken chips.
+Pros: clean separation, no dimming logic.
+Cons: the SPEC is explicit about an in-grid toggle that shows hidden cards
+alongside normal ones (dimmed, badged). A separate mode makes it impossible to
+compare a hidden card with its neighbours to decide whether to unhide it.
+Rejected: contradicts the specified UX.
+
+## Consequences
+
+**Positive**
+- No new runtime dependency; no settings migration.
+- The `filtered()` gate is a single addition; all downstream consumers (grid,
+  count, search, `getVisibleFiles()`) inherit it without changes.
+- Pattern is consistent with `favorite`/`broken`; any future per-note flag would
+  follow the same path.
+
+**Negative**
+- Category counts currently loop `this.items` without filtering; the loop must be
+  updated so counts stay consistent. This is a contained change but is easy to
+  forget.
+- `hideSelected()` issues one `processFrontMatter` call per selected note
+  serially. For large selections this is acceptable (Obsidian's API serialises
+  frontmatter writes anyway), but it is not batched.
+- The "Hide selected" button visibility logic is now tied to two conditions
+  (`selected.size > 0`, independently of `brokenOnly`). `renderGrid()` must
+  manage both buttons' visibility; a slight increase in coupling.
+
+**Neutral**
+- Unhiding via context menu removes the `hidden` key rather than setting it to
+  `false`, keeping frontmatter clean. Both representations are read as `false` by
+  `fm.hidden === true`.
+- The toggle resets on every board open because `showHidden` is an instance
+  field with a `false` initialiser, which is already the desired behaviour.
+
+## References
+
+- SPEC.md `/Users/stefanoferri/Developer/Bookmark/SPEC.md` (hide-bookmarks)
+- ADR-001 (no-backend, mobile-safe constraints)
+- `src/bookmark-view.ts`: `loadBookmarks`, `filtered`, `renderToolbar`,
+  `renderCard`, `showCardMenu`, `deleteBrokenBtn` pattern
+- `styles.css`: `.bookmarker-card-broken`, `.bookmarker-hidden`,
+  `.bookmarker-tag-active` for CSS patterns to mirror

--- a/docs/superpowers/plans/2026-06-16-hide-bookmarks.md
+++ b/docs/superpowers/plans/2026-06-16-hide-bookmarks.md
@@ -1,0 +1,274 @@
+# Plan: Hide bookmarks — 2026-06-16
+
+ADR: `docs/architecture/ADR-002-hide-bookmarks.md`
+
+---
+
+## Task 1 — Extend `BookmarkItem` and `loadBookmarks`
+
+**Files:** `src/bookmark-view.ts`
+
+Add `hidden: boolean` to the `BookmarkItem` interface (after `broken`):
+
+```ts
+hidden: boolean;
+```
+
+In `loadBookmarks`, inside the `items.push({…})` call, add:
+
+```ts
+hidden: fm.hidden === true,
+```
+
+This mirrors the existing `favorite: fm.favorite === true` and
+`broken: fm.broken === true` lines.
+
+No observable contract change for external callers; `BookmarkItem` is internal.
+
+---
+
+## Task 2 — Add `showHidden` in-memory field and wire `filtered()`
+
+**Files:** `src/bookmark-view.ts`
+
+Add the instance field with its private class-field declaration (alongside
+`favoritesOnly` / `brokenOnly`):
+
+```ts
+private showHidden = false;
+```
+
+In `filtered()`, insert as the first guard inside the `.filter()` callback,
+before any other predicate:
+
+```ts
+if (item.hidden && !this.showHidden) return false;
+```
+
+This single gate covers the grid, the "N bookmarks" count, search results, and
+all filter combinations.
+
+---
+
+## Task 3 — Fix category counts to respect hidden visibility
+
+**Files:** `src/bookmark-view.ts`
+
+In `renderCategories()`, replace the counting loop:
+
+```ts
+// Before
+for (const item of this.items) {
+    counts.set(item.folder, (counts.get(item.folder) ?? 0) + 1);
+}
+
+// After
+for (const item of this.items) {
+    if (item.hidden && !this.showHidden) continue;
+    counts.set(item.folder, (counts.get(item.folder) ?? 0) + 1);
+}
+```
+
+This keeps tile counts consistent with the grid. The zero-count case (all items
+hidden) surfaces the "No bookmarks yet." empty state, which is correct.
+
+---
+
+## Task 4 — Add toolbar "Show hidden" chip and "Hide selected" button
+
+**Files:** `src/bookmark-view.ts`
+
+In `renderToolbar()`, after the `brokenChip` block:
+
+```ts
+const showHiddenChip = toolbar.createSpan({
+    cls: "bookmarker-tag-chip",
+    text: "Hidden",
+});
+if (this.showHidden) showHiddenChip.addClass("bookmarker-tag-active");
+showHiddenChip.addEventListener("click", () => {
+    this.showHidden = !this.showHidden;
+    showHiddenChip.toggleClass("bookmarker-tag-active", this.showHidden);
+    this.renderGrid();
+});
+```
+
+After the existing `deleteBrokenBtn` block, add:
+
+```ts
+const hideSelectedBtn = toolbar.createEl("button", {
+    cls: "bookmarker-toolbar-btn bookmarker-hide-selected bookmarker-hidden",
+    text: "Hide selected",
+});
+hideSelectedBtn.addEventListener("click", () => void this.hideSelected());
+this.hideSelectedBtn = hideSelectedBtn;
+```
+
+Add `private hideSelectedBtn!: HTMLButtonElement;` alongside the existing
+`private deleteBrokenBtn!: HTMLButtonElement;` declaration.
+
+---
+
+## Task 5 — Update `renderGrid()` to toggle `hideSelectedBtn` visibility
+
+**Files:** `src/bookmark-view.ts`
+
+In `renderGrid()`, after the existing `deleteBrokenBtn.toggleClass(…)` call,
+add:
+
+```ts
+this.hideSelectedBtn.toggleClass(
+    "bookmarker-hidden",
+    this.selected.size === 0,
+);
+```
+
+The "Hide selected" button appears whenever any card is ticked, regardless of
+filter state. The "Delete broken" button remains gated on `brokenOnly &&
+selected.size > 0` (unchanged).
+
+---
+
+## Task 6 — Add Hide/Unhide to the card context menu
+
+**Files:** `src/bookmark-view.ts`
+
+In `showCardMenu()`, insert a new `menu.addItem` immediately before the
+`menu.addSeparator()` call that precedes "Delete":
+
+```ts
+menu.addItem((i) =>
+    i
+        .setTitle(item.hidden ? "Unhide" : "Hide")
+        .setIcon(item.hidden ? "eye" : "eye-off")
+        .onClick(() => void this.toggleHidden(item)),
+);
+```
+
+Add the private method `toggleHidden`:
+
+```ts
+private async toggleHidden(item: BookmarkItem): Promise<void> {
+    const next = !item.hidden;
+    try {
+        await this.app.fileManager.processFrontMatter(
+            item.file,
+            (fm: Record<string, unknown>) => {
+                if (next) fm.hidden = true;
+                else delete fm.hidden;
+            },
+        );
+        item.hidden = next;
+        this.renderGrid();
+    } catch (error) {
+        const msg = error instanceof Error ? error.message : String(error);
+        new Notice(`Failed to update hidden: ${msg}`);
+    }
+}
+```
+
+Unhiding deletes the key rather than setting `false` to keep frontmatter clean.
+
+---
+
+## Task 7 — Implement `hideSelected()` bulk action
+
+**Files:** `src/bookmark-view.ts`
+
+```ts
+private async hideSelected(): Promise<void> {
+    const targets = this.items.filter((i) => this.selected.has(i.file.path));
+    if (targets.length === 0) return;
+    let failed = 0;
+    for (const item of targets) {
+        try {
+            await this.app.fileManager.processFrontMatter(
+                item.file,
+                (fm: Record<string, unknown>) => {
+                    fm.hidden = true;
+                },
+            );
+            item.hidden = true;
+        } catch {
+            failed++;
+        }
+    }
+    this.selected.clear();
+    if (failed > 0) new Notice(`${failed} hide${failed === 1 ? "" : "s"} failed.`);
+    this.renderGrid();
+}
+```
+
+Idempotent: writing `hidden: true` on an already-hidden note is harmless.
+
+---
+
+## Task 8 — Add CSS for hidden-card visual treatment
+
+**Files:** `styles.css`
+
+Append after the `.bookmarker-card-broken` block:
+
+```css
+/* Card rendered while "Show hidden" is on. */
+.bookmarker-card--hidden {
+    opacity: 0.45;
+}
+
+.bookmarker-card-hidden-badge {
+    position: absolute;
+    bottom: 4px;
+    right: 6px;
+    padding: 1px 6px;
+    border-radius: var(--radius-s);
+    background: var(--background-modifier-cover);
+    color: var(--text-muted);
+    font-size: var(--font-ui-smaller);
+    text-transform: uppercase;
+}
+
+/* When a hidden card also has a broken badge, shift hidden badge to the left. */
+.bookmarker-card--hidden .bookmarker-card-broken {
+    right: 60px;
+}
+
+.bookmarker-hide-selected {
+    color: var(--text-muted);
+}
+```
+
+---
+
+## Task 9 — Wire hidden badge and dim class in `renderCard()`
+
+**Files:** `src/bookmark-view.ts`
+
+In `renderCard()`, after the existing `if (item.broken)` badge block:
+
+```ts
+if (item.hidden && this.showHidden) {
+    card.addClass("bookmarker-card--hidden");
+    cover.createSpan({ cls: "bookmarker-card-hidden-badge", text: "hidden" });
+}
+```
+
+This runs only when the card is visible (the toggle is on), so the class and
+badge are never applied to invisible cards.
+
+---
+
+## Verification checklist (manual, no unit-test suite)
+
+- `npx tsc -noEmit -skipLibCheck` passes.
+- `npx eslint src/` passes (no `no-static-styles-assignment` violations).
+- `npm run build` completes without error.
+- Context menu on a visible card shows "Hide"; after clicking it the card
+  disappears from the grid (toggle off) and the count decrements.
+- Enabling "Show hidden" reveals the card dimmed with "hidden" badge.
+- "Unhide" from context menu restores the card to normal.
+- Selecting cards and clicking "Hide selected" hides all of them at once;
+  the "Hide selected" button disappears after the selection clears.
+- Category counts on the landing exclude hidden items when toggle is off.
+- A card that is hidden AND broken: when shown, both the "broken" and "hidden"
+  badges render; the "broken" badge shifts left per the CSS rule.
+- Reopening the board resets `showHidden` to false (hidden cards not shown).

--- a/src/bookmark-view.ts
+++ b/src/bookmark-view.ts
@@ -49,6 +49,7 @@ interface BookmarkItem {
 	type: string;
 	favorite: boolean;
 	broken: boolean;
+	hidden: boolean;
 	description: string;
 }
 
@@ -64,6 +65,7 @@ export class BookmarkView extends ItemView {
 	private typeFilter = "";
 	private favoritesOnly = false;
 	private brokenOnly = false;
+	private showHidden = false;
 	/** Landing shows category tiles; entering one switches to the card grid. */
 	private viewMode: "categories" | "cards" = "categories";
 	/** The category (folder, "" = Uncategorized) entered from a tile, else null. */
@@ -80,6 +82,7 @@ export class BookmarkView extends ItemView {
 	private tagSectionEl!: HTMLElement;
 	private countEl!: HTMLElement;
 	private deleteBrokenBtn!: HTMLButtonElement;
+	private hideSelectedBtn!: HTMLButtonElement;
 
 	constructor(leaf: WorkspaceLeaf, plugin: BookmarkerPlugin) {
 		super(leaf);
@@ -276,6 +279,7 @@ export class BookmarkView extends ItemView {
 
 		const counts = new Map<string, number>();
 		for (const item of this.items) {
+			if (item.hidden && !this.showHidden) continue;
 			counts.set(item.folder, (counts.get(item.folder) ?? 0) + 1);
 		}
 
@@ -370,6 +374,7 @@ export class BookmarkView extends ItemView {
 				type: asString(fm.type) || "link",
 				favorite: fm.favorite === true,
 				broken: fm.broken === true,
+				hidden: fm.hidden === true,
 				description: asString(fm.description),
 			});
 		}
@@ -480,6 +485,17 @@ export class BookmarkView extends ItemView {
 			this.renderGrid();
 		});
 
+		const showHiddenChip = toolbar.createSpan({
+			cls: "bookmarker-tag-chip",
+			text: "Hidden",
+		});
+		if (this.showHidden) showHiddenChip.addClass("bookmarker-tag-active");
+		showHiddenChip.addEventListener("click", () => {
+			this.showHidden = !this.showHidden;
+			showHiddenChip.toggleClass("bookmarker-tag-active", this.showHidden);
+			this.renderGrid();
+		});
+
 		const selectAll = toolbar.createEl("button", {
 			cls: "bookmarker-toolbar-btn",
 			text: "Select all",
@@ -504,6 +520,13 @@ export class BookmarkView extends ItemView {
 		});
 		deleteBrokenBtn.addEventListener("click", () => void this.deleteBrokenSelected());
 		this.deleteBrokenBtn = deleteBrokenBtn;
+
+		const hideSelectedBtn = toolbar.createEl("button", {
+			cls: "bookmarker-toolbar-btn bookmarker-hide-selected bookmarker-hidden",
+			text: "Hide selected",
+		});
+		hideSelectedBtn.addEventListener("click", () => void this.hideSelected());
+		this.hideSelectedBtn = hideSelectedBtn;
 
 		const sizeSel = toolbar.createEl("select", { cls: "bookmarker-size-select" });
 		for (const [value, label] of [
@@ -713,6 +736,10 @@ export class BookmarkView extends ItemView {
 			"bookmarker-hidden",
 			!(this.brokenOnly && this.selected.size > 0),
 		);
+		this.hideSelectedBtn.toggleClass(
+			"bookmarker-hidden",
+			this.selected.size === 0,
+		);
 		if (items.length === 0) {
 			this.gridEl.createDiv({
 				cls: "bookmarker-empty",
@@ -728,6 +755,7 @@ export class BookmarkView extends ItemView {
 		// Fuzzy match (typo/word-order tolerant) over title, domain, url, tags, description.
 		const matcher = this.search ? prepareFuzzySearch(this.search) : null;
 		const result = this.items.filter((item) => {
+			if (item.hidden && !this.showHidden) return false;
 			// Category scope: constrain to the entered category unless scope is global.
 			if (
 				this.searchScope === "category" &&
@@ -774,7 +802,11 @@ export class BookmarkView extends ItemView {
 		const srcTags = new Set(source.tags.map((t) => t.toLowerCase()));
 		const srcDomain = source.domain.toLowerCase().replace(/^www\./, "");
 		const scored = this.items
-			.filter((c) => c.file.path !== source.file.path)
+			.filter((c) => {
+				if (c.file.path === source.file.path) return false;
+				if (c.hidden && !this.showHidden) return false;
+				return true;
+			})
 			.map((c) => {
 				const sharedTags = c.tags.filter((t) => srcTags.has(t.toLowerCase())).length;
 				const cDomain = c.domain.toLowerCase().replace(/^www\./, "");
@@ -854,6 +886,10 @@ export class BookmarkView extends ItemView {
 		if (item.broken) {
 			cover.createSpan({ cls: "bookmarker-card-broken", text: "broken" });
 		}
+		if (item.hidden && this.showHidden) {
+			card.addClass("bookmarker-card--hidden");
+			cover.createSpan({ cls: "bookmarker-card-hidden-badge", text: "hidden" });
+		}
 
 		card.createDiv({ cls: "bookmarker-card-title", text: item.title });
 		if (item.domain) {
@@ -914,6 +950,12 @@ export class BookmarkView extends ItemView {
 				.setIcon("tags")
 				.onClick(() => void this.regenerateTags(item)),
 		);
+		menu.addItem((i) =>
+			i
+				.setTitle(item.hidden ? "Unhide" : "Hide")
+				.setIcon(item.hidden ? "eye" : "eye-off")
+				.onClick(() => void this.toggleHidden(item)),
+		);
 		menu.addSeparator();
 		menu.addItem((i) =>
 			i
@@ -951,6 +993,24 @@ export class BookmarkView extends ItemView {
 		}
 	}
 
+	private async toggleHidden(item: BookmarkItem): Promise<void> {
+		const next = !item.hidden;
+		try {
+			await this.app.fileManager.processFrontMatter(
+				item.file,
+				(fm: Record<string, unknown>) => {
+					if (next) fm.hidden = true;
+					else delete fm.hidden;
+				},
+			);
+			item.hidden = next;
+			this.renderGrid();
+		} catch (error) {
+			const msg = error instanceof Error ? error.message : String(error);
+			new Notice(`Failed to update hidden: ${msg}`);
+		}
+	}
+
 	private async deleteBrokenSelected(): Promise<void> {
 		const targets = this.items.filter(
 			(i) => i.broken && this.selected.has(i.file.path),
@@ -966,6 +1026,29 @@ export class BookmarkView extends ItemView {
 			}
 		}
 		if (failed > 0) new Notice(`${failed} deletion${failed === 1 ? "" : "s"} failed.`);
+	}
+
+	private async hideSelected(): Promise<void> {
+		const targets = this.items.filter((i) => this.selected.has(i.file.path));
+		if (targets.length === 0) return;
+		let failed = 0;
+		for (const item of targets) {
+			try {
+				await this.app.fileManager.processFrontMatter(
+					item.file,
+					(fm: Record<string, unknown>) => {
+						fm.hidden = true;
+					},
+				);
+				item.hidden = true;
+			} catch {
+				failed++;
+			}
+		}
+		this.selected.clear();
+		if (failed > 0)
+			new Notice(`${failed} bookmark${failed === 1 ? "" : "s"} could not be hidden.`);
+		this.renderGrid();
 	}
 
 	private moveToCategory(item: BookmarkItem): void {

--- a/styles.css
+++ b/styles.css
@@ -453,6 +453,31 @@
 	text-transform: uppercase;
 }
 
+.bookmarker-card--hidden {
+	--bm-hidden-badge-w: 54px;
+	opacity: 0.45;
+}
+
+.bookmarker-card-hidden-badge {
+	position: absolute;
+	bottom: 4px;
+	right: 6px;
+	padding: 1px 6px;
+	border-radius: var(--radius-s);
+	background: var(--background-modifier-cover);
+	color: var(--text-muted);
+	font-size: var(--font-ui-smaller);
+	text-transform: uppercase;
+}
+
+.bookmarker-card--hidden .bookmarker-card-broken {
+	right: calc(6px + var(--bm-hidden-badge-w));
+}
+
+.bookmarker-hide-selected {
+	color: var(--text-muted);
+}
+
 .bookmarker-card-cover img {
 	width: 100%;
 	height: 100%;


### PR DESCRIPTION
Adds a per-note `hidden` frontmatter flag and an in-memory `showHidden` toggle (default off) that keeps selected bookmarks in the vault but out of the board until you ask for them.

## What changed
- **Toolbar:** a "Hidden" chip reveals hidden cards dimmed with a badge; a "Hide selected" button appears only when the selection is non-empty.
- **Context menu:** per-card Hide/Unhide writes or removes the `hidden` key via `processFrontMatter` (unhide deletes the key to keep frontmatter clean).
- **Bulk:** `hideSelected()` sets `hidden` on all selected notes, then re-renders.
- **Filter coverage:** a single guard in `filtered()` gates the grid, the count label, search, and category counts. Related mode honors it too.
- **CSS:** `bookmarker-card--hidden` dimming plus the hidden badge; the broken badge shifts left when both badges show. No inline style assignments.

The toggle is intentionally not persisted: every time the board opens, hidden bookmarks start excluded.

## Verification
- `npx tsc -noEmit -skipLibCheck`, `npx eslint src/ --max-warnings=0`, and `npm run build` all pass.
- A review cycle found and fixed 3 issues (Related-mode leak, badge-offset magic number, error-copy wording); layout audit clean.

Design: `docs/architecture/ADR-002-hide-bookmarks.md`