### PR TITLE
feat(board): add an optional password lock for the Hidden toggle

### DIFF
--- a/src/bookmark-view.ts
+++ b/src/bookmark-view.ts
@@ -23,6 +23,7 @@ import { normalizeTags } from "./tags";
 import { ManageTagModal } from "./manage-tag-modal";
 import { changeTagEverywhere, countTagUsage } from "./tag-ops";
 import { refreshBookmarkCard } from "./refresh-card";
+import { hashPassword, PasswordPromptModal } from "./password-modal";
 
 export const BOOKMARK_VIEW_TYPE = "bookmarker-grid";
 const MAX_CARD_TAGS = 4;
@@ -66,6 +67,8 @@ export class BookmarkView extends ItemView {
 	private favoritesOnly = false;
 	private brokenOnly = false;
 	private showHidden = false;
+	/** Per-session unlock for the password-gated Hidden toggle; resets on each new board. */
+	private hiddenUnlocked = false;
 	/** Landing shows category tiles; entering one switches to the card grid. */
 	private viewMode: "categories" | "cards" = "categories";
 	/** The category (folder, "" = Uncategorized) entered from a tile, else null. */
@@ -491,9 +494,30 @@ export class BookmarkView extends ItemView {
 		});
 		if (this.showHidden) showHiddenChip.addClass("bookmarker-tag-active");
 		showHiddenChip.addEventListener("click", () => {
-			this.showHidden = !this.showHidden;
-			showHiddenChip.toggleClass("bookmarker-tag-active", this.showHidden);
-			this.renderGrid();
+			const lockHash = this.plugin.settings.hiddenLockHash;
+			// Turning off, no lock, or already unlocked this session → toggle directly.
+			if (this.showHidden || !lockHash || this.hiddenUnlocked) {
+				this.showHidden = !this.showHidden;
+				showHiddenChip.toggleClass("bookmarker-tag-active", this.showHidden);
+				this.renderGrid();
+				return;
+			}
+			// Locked and turning on → require the password first.
+			new PasswordPromptModal(this.app, (entered) => {
+				void (async () => {
+					try {
+						if ((await hashPassword(entered)) !== lockHash) {
+							new Notice("Incorrect password.");
+							return;
+						}
+						this.hiddenUnlocked = true;
+						this.showHidden = true;
+						this.renderGrid();
+					} catch {
+						new Notice("Could not verify password.");
+					}
+				})();
+			}).open();
 		});
 
 		const selectAll = toolbar.createEl("button", {

--- a/src/password-modal.ts
+++ b/src/password-modal.ts
@@ -1,0 +1,129 @@
+import { App, Modal, Notice, Setting } from "obsidian";
+
+/** SHA-256 hex digest of a password. Soft lock only — not encryption. */
+export async function hashPassword(password: string): Promise<string> {
+	const data = new TextEncoder().encode(password);
+	const digest = await crypto.subtle.digest("SHA-256", data);
+	return Array.from(new Uint8Array(digest))
+		.map((b) => b.toString(16).padStart(2, "0"))
+		.join("");
+}
+
+/** Prompt for the Hidden-cards password. Calls onSubmit with the entered value. */
+export class PasswordPromptModal extends Modal {
+	private value = "";
+	private readonly onSubmit: (password: string) => void;
+
+	constructor(app: App, onSubmit: (password: string) => void) {
+		super(app);
+		this.onSubmit = onSubmit;
+	}
+
+	onOpen(): void {
+		const { contentEl } = this;
+		contentEl.createEl("h2", { text: "Hidden cards locked" });
+		contentEl.createEl("p", {
+			cls: "bookmarker-domain-notice",
+			text: "Enter the password to show hidden bookmarks.",
+		});
+
+		new Setting(contentEl).addText((text) => {
+			text.inputEl.type = "password";
+			text.setPlaceholder("Password…").onChange((v) => {
+				this.value = v;
+			});
+			text.inputEl.addClass("bookmarker-wide-input");
+			text.inputEl.addEventListener("keydown", (e) => {
+				if (e.key === "Enter") {
+					e.preventDefault();
+					this.submit();
+				}
+			});
+			window.setTimeout(() => text.inputEl.focus(), 0);
+		});
+
+		new Setting(contentEl)
+			.addButton((button) => button.setButtonText("Unlock").setCta().onClick(() => this.submit()))
+			.addButton((button) => button.setButtonText("Cancel").onClick(() => this.close()));
+	}
+
+	private submit(): void {
+		if (!this.value) {
+			new Notice("Please enter a password.");
+			return;
+		}
+		const value = this.value;
+		this.close();
+		this.onSubmit(value);
+	}
+
+	onClose(): void {
+		this.contentEl.empty();
+	}
+}
+
+/** Set or change the Hidden-cards password. Requires a matching confirmation. */
+export class SetPasswordModal extends Modal {
+	private password = "";
+	private confirm = "";
+	private readonly onSet: (password: string) => void;
+
+	constructor(app: App, onSet: (password: string) => void) {
+		super(app);
+		this.onSet = onSet;
+	}
+
+	onOpen(): void {
+		const { contentEl } = this;
+		contentEl.createEl("h2", { text: "Hidden cards password" });
+		contentEl.createEl("p", {
+			cls: "bookmarker-domain-notice",
+			text: "Soft lock only. Notes stay readable as Markdown files in your vault.",
+		});
+
+		new Setting(contentEl).setName("Password").addText((text) => {
+			text.inputEl.type = "password";
+			text.setPlaceholder("Password…").onChange((v) => {
+				this.password = v;
+			});
+			text.inputEl.addClass("bookmarker-wide-input");
+			window.setTimeout(() => text.inputEl.focus(), 0);
+		});
+
+		new Setting(contentEl).setName("Confirm").addText((text) => {
+			text.inputEl.type = "password";
+			text.setPlaceholder("Repeat password…").onChange((v) => {
+				this.confirm = v;
+			});
+			text.inputEl.addClass("bookmarker-wide-input");
+			text.inputEl.addEventListener("keydown", (e) => {
+				if (e.key === "Enter") {
+					e.preventDefault();
+					this.submit();
+				}
+			});
+		});
+
+		new Setting(contentEl)
+			.addButton((button) => button.setButtonText("Save").setCta().onClick(() => this.submit()))
+			.addButton((button) => button.setButtonText("Cancel").onClick(() => this.close()));
+	}
+
+	private submit(): void {
+		if (!this.password) {
+			new Notice("Password cannot be empty.");
+			return;
+		}
+		if (this.password !== this.confirm) {
+			new Notice("Passwords do not match.");
+			return;
+		}
+		const password = this.password;
+		this.close();
+		this.onSet(password);
+	}
+
+	onClose(): void {
+		this.contentEl.empty();
+	}
+}

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -2,6 +2,7 @@ import { App, Notice, PluginSettingTab, Setting } from "obsidian";
 import type BookmarkerPlugin from "./main";
 import { testClaudeConnection } from "./classifier";
 import { testRaindropToken } from "./raindrop";
+import { hashPassword, SetPasswordModal } from "./password-modal";
 
 export interface BookmarkerSettings {
 	anthropicApiKey: string;
@@ -30,6 +31,8 @@ export interface BookmarkerSettings {
 	useFileNameAsTitle: boolean;
 	/** Per-category color + icon for the category landing tiles, keyed by folder name ("" = Uncategorized). */
 	categoryStyles: Record<string, { color: string; icon: string }>;
+	/** SHA-256 hex of the soft-lock password for the Hidden toggle ("" / null = no lock). Not encryption. */
+	hiddenLockHash: string | null;
 }
 
 export const DEFAULT_SETTINGS: BookmarkerSettings = {
@@ -56,6 +59,7 @@ export const DEFAULT_SETTINGS: BookmarkerSettings = {
 	sortMode: "added",
 	useFileNameAsTitle: false,
 	categoryStyles: {},
+	hiddenLockHash: null,
 };
 
 export class BookmarkerSettingTab extends PluginSettingTab {
@@ -415,5 +419,59 @@ export class BookmarkerSettingTab extends PluginSettingTab {
 						button.setButtonText("Test").setDisabled(false);
 					}),
 			);
+
+		new Setting(containerEl).setName("Hidden cards").setHeading();
+
+		const lockSection = containerEl.createDiv();
+		const renderLockSection = (): void => {
+			lockSection.empty();
+			if (this.plugin.settings.hiddenLockHash) {
+				new Setting(lockSection)
+					.setName("Password")
+					.setDesc(
+						"A password is set; the Hidden toggle asks for it before revealing hidden cards. " +
+							"Soft lock only, not encryption: the notes stay readable as Markdown files in your vault.",
+					)
+					.addButton((button) =>
+						button.setButtonText("Change").onClick(() => this.promptSetPassword(renderLockSection)),
+					)
+					.addButton((button) =>
+						button.setButtonText("Remove").onClick(() => {
+							this.plugin.settings.hiddenLockHash = null;
+							void this.plugin.saveSettings();
+							renderLockSection();
+						}),
+					);
+			} else {
+				new Setting(lockSection)
+					.setName("Password")
+					.setDesc(
+						"Optional: require a password before the Hidden toggle reveals hidden cards. " +
+							"Soft lock only, not encryption: the notes stay readable as Markdown files in your vault.",
+					)
+					.addButton((button) =>
+						button
+							.setButtonText("Set password")
+							.setCta()
+							.onClick(() => this.promptSetPassword(renderLockSection)),
+					);
+			}
+		};
+		renderLockSection();
+	}
+
+	private promptSetPassword(refresh: () => void): void {
+		new SetPasswordModal(this.app, (password) => {
+			void (async () => {
+				try {
+					this.plugin.settings.hiddenLockHash = await hashPassword(password);
+					await this.plugin.saveSettings();
+					new Notice("Hidden cards password set.");
+					refresh();
+				} catch {
+					new Notice("Could not set password.");
+				}
+			})();
+		}).open();
 	}
 }


### PR DESCRIPTION
Adds an optional password gate in front of the board's "Hidden" toggle.

## What changed
- **Settings → Hidden cards:** Set / Change / Remove a password. The SHA-256 hash is stored in settings; the plaintext password is never saved.
- **Hidden toggle:** when a password is set, clicking "Hidden" prompts for it. A correct entry unlocks hidden cards for the current board session; the lock re-arms when the board reopens (mirrors how `showHidden` already resets per open). Turning the toggle off, or with no password set, behaves as before.
- **New file** `src/password-modal.ts`: `hashPassword` (Web Crypto, mobile-safe), `PasswordPromptModal`, `SetPasswordModal` (with confirm field).

## Scope and honesty
This is a **casual deterrent, not encryption**. The bookmarks remain plain Markdown in the vault and `data.json` (with the hash) syncs in `.obsidian`, so the notes are still readable via the file explorer, core search, other plugins, or with this plugin disabled. The settings UI states this plainly. For real protection: disk encryption / an encrypted container / a content-encryption plugin.

## Verification
- `npx tsc -noEmit -skipLibCheck`, `npx eslint src/ --max-warnings=0`, and `npm run build` all pass.
- A review pass fixed 2 issues before commit: unhandled `crypto.subtle.digest` rejection (both call sites now `try/catch` with a Notice) and a silent empty-password submit (now shows a Notice).
- Deployed to a test vault for manual verification of set / unlock / wrong-password / session re-lock / change / remove.