### PR TITLE
ci(release): bump actions to Node 24 runtime versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,19 +13,15 @@ permissions:
   id-token: write
   attestations: write
 
-env:
-  # Run the bundled JS actions on Node 24; Node 20 is being removed from the runners.
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
-
 jobs:
   release:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: "22"
           cache: "npm"
@@ -37,7 +33,7 @@ jobs:
         run: npm run build
 
       - name: Attest build provenance
-        uses: actions/attest-build-provenance@v1
+        uses: actions/attest-build-provenance@v2
         with:
           subject-path: |
             main.js


### PR DESCRIPTION
Clears the Node 20 deprecation annotation on the release workflow.

## What changed
- `actions/checkout@v4` → `@v5`
- `actions/setup-node@v4` → `@v5` (keeps `node-version: "22"`, `cache: "npm"`)
- `actions/attest-build-provenance@v1` → `@v2`
- Removes the `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` env workaround — redundant once all three actions target Node 24 natively.

## Why
GitHub is removing Node 20 from the runners. The 0.1.23 and 0.1.24 releases succeeded but emitted a deprecation annotation because the pinned action majors still bundled Node 20 JS. Bumping the majors makes them run on Node 24 directly.

## Verification
- YAML parses cleanly; no source change (`tsc` unaffected).
- Real validation is the next tagged release: it should run with no Node 20 deprecation annotation.