### PR TITLE
fix(board): replace fuzzy board search with substring token match

### DIFF
--- a/src/bookmark-view.ts
+++ b/src/bookmark-view.ts
@@ -4,7 +4,6 @@ import {
 	Menu,
 	Notice,
 	normalizePath,
-	prepareFuzzySearch,
 	setIcon,
 	TFile,
 	WorkspaceLeaf,
@@ -776,8 +775,9 @@ export class BookmarkView extends ItemView {
 
 	private filtered(): BookmarkItem[] {
 		if (this.relatedTo) return this.relatedItems(this.relatedTo);
-		// Fuzzy match (typo/word-order tolerant) over title, domain, url, tags, description.
-		const matcher = this.search ? prepareFuzzySearch(this.search) : null;
+		// Substring token AND: every whitespace-separated word must appear (case-insensitive)
+		// in the item's searchable text. Predictable and word-order independent.
+		const terms = this.search ? this.search.split(/\s+/).filter(Boolean) : [];
 		const result = this.items.filter((item) => {
 			if (item.hidden && !this.showHidden) return false;
 			// Category scope: constrain to the entered category unless scope is global.
@@ -799,7 +799,10 @@ export class BookmarkView extends ItemView {
 			if (this.favoritesOnly && !item.favorite) return false;
 			if (this.brokenOnly && !item.broken) return false;
 			if (this.tagFilter && !item.tags.includes(this.tagFilter)) return false;
-			if (matcher && !matcher(haystack(item))) return false;
+			if (terms.length) {
+				const text = haystack(item).toLowerCase();
+				if (!terms.every((term) => text.includes(term))) return false;
+			}
 			return true;
 		});
 		return this.sortItems(result);


### PR DESCRIPTION
## Problem

Board search never filtered. Typing a query left almost every bookmark visible.

Root cause: `filtered()` used `prepareFuzzySearch` over one concatenated blob of `title + domain + url + tags + description`. Obsidian's fuzzy match is subsequence based, so a short query (e.g. `obsidian`, letters o-b-s-i-d-i-a-n) appears as a subsequence inside nearly any long description. The match check only tested truthiness, with no score threshold, so unrelated bookmarks (Yellow Tech, Learnn, Swisse) all passed.

## Fix

Substring token AND: split the query into whitespace-separated words and require each word as a case-insensitive substring of the searchable text. Predictable, word-order independent, no spurious matches.

- `obsidian` → only bookmarks that actually contain "obsidian"
- `obsidian plugin` → only bookmarks containing both words, in any order

## Scope

One file, `src/bookmark-view.ts`. The tag filter (`includes`) was already substring based and is unchanged.

## Verification

`npm run build` (tsc type-check + esbuild production) and `npm run lint` both clean.
