### PR TITLE
fix(board): carry search text and focus from categories to card view

### DIFF
--- a/src/bookmark-view.ts
+++ b/src/bookmark-view.ts
@@ -274,6 +274,11 @@ export class BookmarkView extends ItemView {
 			this.activeCategory = null;
 			this.viewMode = "cards";
 			this.rebuild();
+			// rebuild() swaps in the toolbar's search input; carry focus and cursor there
+			// so the user can keep typing instead of having to click back in.
+			const newSearchInput = this.contentEl.querySelector<HTMLInputElement>(".bookmarker-search");
+			newSearchInput?.focus();
+			newSearchInput?.setSelectionRange(newSearchInput.value.length, newSearchInput.value.length);
 		});
 
 		const refresh = header.createEl("button", { cls: "bookmarker-toolbar-btn", text: "Refresh" });
@@ -439,6 +444,7 @@ export class BookmarkView extends ItemView {
 			cls: "bookmarker-search",
 			attr: { type: "search", placeholder: "Search bookmarks…" },
 		});
+		searchInput.value = this.search;
 		searchInput.addEventListener("input", () => {
 			this.search = searchInput.value.toLowerCase().trim();
 			this.renderGrid();


### PR DESCRIPTION
Typing in the categories search box switched to card view on the first keystroke but left the new input empty and unfocused, forcing the user to click back in and retype the whole query.

Fix in `src/bookmark-view.ts`:
- `renderToolbar()` now initializes the card-view search input from `this.search`, so the query typed in Categories view is not lost.
- The Categories search handler refocuses the new toolbar search input after `rebuild()` and moves the cursor to the end, so typing continues uninterrupted.

## Test plan
- [ ] Reload the plugin in Obsidian
- [ ] From the Categories view, type in the search box and confirm it switches to Cards view without losing the typed text or focus